### PR TITLE
proposed alternative to avoid parsing manually the token

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
@@ -83,7 +83,7 @@ public class KapuaTokenAuthenticationFilter extends AuthenticatingFilter {
 
     @Override
     protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws Exception {
-        // Continue with the filter chain, because CORS headers are still needed for bad authorization or token expired
+        // Continue with the filter chain, because CORS headers are still needed
         return true;
     }
 
@@ -92,9 +92,9 @@ public class KapuaTokenAuthenticationFilter extends AuthenticatingFilter {
     private String handleAuthException(AuthenticationException ae) {
         String errorMessageInResponse = "An error occurred during the authentication process with the provided access token";
         if (ae instanceof MalformedAccessTokenException ||
-            ae instanceof InvalidatedAccessTokenException ||
-            ae instanceof ExpiredAccessTokenException) {
-                errorMessageInResponse = ae.getMessage();
+                ae instanceof InvalidatedAccessTokenException ||
+                ae instanceof ExpiredAccessTokenException) {
+            errorMessageInResponse = ae.getMessage();
         }
         return errorMessageInResponse;
     }

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -115,10 +115,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
         <!-- -->
         <!-- Test Dependencies-->

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -12,11 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.DisabledAccountException;
 import org.apache.shiro.authc.ExpiredCredentialsException;
@@ -28,7 +27,6 @@ import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.KapuaParsingException;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.KapuaUnauthenticatedException;
 import org.eclipse.kapua.commons.logging.LoggingMdcKeys;
@@ -94,7 +92,12 @@ import org.eclipse.kapua.service.user.UserService;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.NumericDate;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.jwt.consumer.JwtContext;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +105,8 @@ import org.slf4j.MDC;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -350,33 +353,20 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         return accessToken;
     }
 
-    public AccessToken findAccessToken(String jwt) throws KapuaException {
-        final String idToken = extractFieldFromJwtPayload(jwt, AccessTokenAttributes.TOKEN_IDENTIFIER);
-        AccessToken accessToken;
-        accessToken = KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenId(idToken));
-        return accessToken;
-    }
+    public AccessToken findAccessToken(String jwtToken) throws KapuaException {
+        final JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+                .setSkipAllValidators()
+                .setDisableRequireSignature()
+                .setSkipSignatureVerification()
+                .build();
 
-    /**
-     * Parse the provided 'jwt', validates it and extract a requested field from the payload. see https://metamug.com/article/security/decode-jwt-java.html for more info
-     *
-     * @param jwt The json web token to be validated. hopefully, will contain a valid payload from which the 'fieldName' value will be extracted
-     * @param fieldName  The name of the filed to extract
-     * @return The value for the requested 'fieldName'
-     * @throws KapuaParsingException if the validation of the jwt fails OR the "fieldname" is missing from the payload. NB: this method ignores validation of the signature
-     * @since 2.0.0
-     */
-    private String extractFieldFromJwtPayload(String jwt, String fieldName) throws KapuaParsingException {
         try {
-            String[] parts = jwt.split("\\.");
-            String headerToken = parts[0];
-            String payloadToken = parts[1];
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonHeader = objectMapper.readTree(Base64.getUrlDecoder().decode(headerToken));
-            JsonNode jsonPayload = objectMapper.readTree(Base64.getUrlDecoder().decode(payloadToken));
-            return jsonPayload.get(fieldName).asText();
-        } catch (Exception e) {
-            throw new KapuaParsingException("Jwt token (header or payload)");
+            final JwtContext jwtContext = jwtConsumer.process(jwtToken);
+            final String tokenIdentified = Optional.ofNullable(jwtContext.getJwtClaims().getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class))
+                    .orElseThrow(() -> new AuthenticationException());
+            return KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenId(tokenIdentified));
+        } catch (InvalidJwtException | MalformedClaimException e) {
+            throw new AuthenticationException();
         }
     }
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccessTokenException;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.InvalidatedAccessTokenException;
@@ -35,7 +36,6 @@ import org.eclipse.kapua.service.authentication.shiro.exceptions.MalformedAccess
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-import org.eclipse.kapua.service.authentication.AuthenticationService;
 
 import java.util.Date;
 
@@ -135,4 +135,5 @@ public class AccessTokenAuthenticatingRealm extends KapuaAuthenticatingRealm {
     public boolean supports(AuthenticationToken authenticationToken) {
         return authenticationToken instanceof AccessTokenCredentialsImpl;
     }
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
@@ -18,17 +18,18 @@ import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.user.User;
+import org.jose4j.jwt.JwtClaims;
 
 /**
  * Kapua {@link AuthenticationInfo} implementation
  *
  * @since 1.0
- *
  */
 public class SessionAuthenticationInfo implements AuthenticationInfo {
 
     private static final long serialVersionUID = -8682457531010599453L;
 
+    private final JwtClaims jwtClaims;
     private String realmName;
     private Account account;
     private User user;
@@ -42,14 +43,21 @@ public class SessionAuthenticationInfo implements AuthenticationInfo {
      * @param user
      * @param accessToken
      */
-    public SessionAuthenticationInfo(String realmName,
+    public SessionAuthenticationInfo(
+            JwtClaims jwtClaims,
+            String realmName,
             Account account,
             User user,
             AccessToken accessToken) {
+        this.jwtClaims = jwtClaims;
         this.realmName = realmName;
         this.account = account;
         this.user = user;
         this.accessToken = accessToken;
+    }
+
+    public JwtClaims getJwtClaims() {
+        return jwtClaims;
     }
 
     /**

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfoTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfoTest.java
@@ -42,7 +42,7 @@ public class SessionAuthenticationInfoTest {
     @Test
     public void sessionAuthenticationInfoTest() {
         for (String realmName : realmNames) {
-            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, user, accessToken);
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, realmName, account, user, accessToken);
             Assert.assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
             Assert.assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
             Assert.assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
@@ -54,7 +54,7 @@ public class SessionAuthenticationInfoTest {
 
     @Test
     public void sessionAuthenticationInfoNullNameTest() {
-        SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, account, user, accessToken);
+        SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, null, account, user, accessToken);
         Assert.assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
         Assert.assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
         Assert.assertNull("Null expected.", sessionAuthenticationInfo.getRealmName());
@@ -71,7 +71,7 @@ public class SessionAuthenticationInfoTest {
     @Test
     public void sessionAuthenticationInfoNullAccountTest() {
         for (String realmName : realmNames) {
-            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, null, user, accessToken);
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, realmName, null, user, accessToken);
             Assert.assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
             Assert.assertNull("Null expected.", sessionAuthenticationInfo.getAccount());
             Assert.assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
@@ -84,7 +84,7 @@ public class SessionAuthenticationInfoTest {
     @Test
     public void sessionAuthenticationInfoNullUserTest() {
         for (String realmName : realmNames) {
-            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, null, accessToken);
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, realmName, account, null, accessToken);
             Assert.assertNull("Null expected.", sessionAuthenticationInfo.getUser());
             Assert.assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
             Assert.assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
@@ -102,7 +102,7 @@ public class SessionAuthenticationInfoTest {
     @Test
     public void sessionAuthenticationInfoNullAccessTokenTest() {
         for (String realmName : realmNames) {
-            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, user, null);
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, realmName, account, user, null);
             Assert.assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
             Assert.assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
             Assert.assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());


### PR DESCRIPTION
According to [Shiro's documentation](https://shiro.apache.org/realm.html), it's ok to perform data retrieval and credentials maching in the Realm:
```
Handling supported AuthenticationTokens
If a Realm supports a submitted AuthenticationToken, the Authenticator will call the Realm’s [getAuthenticationInfo(token)](https://shiro.apache.org/static/current/apidocs/org/apache/shiro/realm/Realm.html#getAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken)) method. This effectively represents an authentication attempt with the Realm’s backing data source. The method, in order:

1. Inspects the token for the identifying principal (account identifying information)
2. Based on the principal, looks up corresponding account data in the data source
3. Ensures that the token’s supplied credentials matches those stored in the data store
4. If the credentials match, an [AuthenticationInfo](https://shiro.apache.org/static/current/apidocs/org/apache/shiro/authc/AuthenticationInfo.html) instance is returned that encapsulates the account data in a format Shiro understands
5. If the credentials DO NOT match, an [AuthenticationException](https://shiro.apache.org/static/current/apidocs/org/apache/shiro/authc/AuthenticationException.html) is thrown

```
So I merged the code that was in the CredentialsMatcher in the main realm's class. (CredentialsMatcher is supported but not mandatory for the Realm's functionality - can be replaced by a pass-through implementation like in this case)